### PR TITLE
Makefile.octave: Fix Makefile for Octave 4.2.0

### DIFF
--- a/Makefile.octave
+++ b/Makefile.octave
@@ -21,7 +21,7 @@ default : $(TARGET).$(OCTEXT)
 	CPPFLAGS="$(CPPFLAGS)" \
 		CFLAGS="$(CFLAGS)" \
 		LDFLAGS="$(LDFLAGS) $(LIBS)" \
-		$(OCT_MEX) -o $@ $<
+		$(OCT_MEX) -o $@ $^
 
 %.o : %.c $(HEADERS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
I had to adapt the Makefile (has this worked before with just sqlite.c without structlist?)